### PR TITLE
chore(pdb): Add pod distruption budget for rumba to make admin tasks easier.

### DIFF
--- a/k8s/templates/pdb.yaml
+++ b/k8s/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.podDisruptionBudget.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+{{- end }}

--- a/k8s/values/stage.yaml
+++ b/k8s/values/stage.yaml
@@ -19,3 +19,9 @@ deployment:
 
 settings:
   metrics__statsd_label: "rumba_stage"
+
+podDisruptionBudget:
+  enabled: true
+  name: rumba
+  labels: {}
+  minAvailable: 1


### PR DESCRIPTION
Please note, the comparison for kube version looks at your local `kubectl` version. It is possible for example to have a kube 1.22 client and run against a 1.19 server (our current version) which would try to use the `policy/v1` apiVersion instead of the beta.