### PR TITLE
feature(hpa): Add horizontal pod autoscaler configuration

### DIFF
--- a/k8s/templates/hpa.yaml
+++ b/k8s/templates/hpa.yaml
@@ -1,0 +1,15 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}-hpa
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}-deployment
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  targetCPUUtilizationPercentage: 80

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -25,3 +25,7 @@ settings:
 
 podDisruptionBudget:
   enabled: false
+
+hpa:
+  minReplicas: 2
+  maxReplicas: 10


### PR DESCRIPTION
With the move to rumba we have a dangling web hpa. This adds the same kind of HPA we had for web for rumba.