### PR TITLE
handle missing keys in elastic _source

### DIFF
--- a/src/api/elastic.rs
+++ b/src/api/elastic.rs
@@ -221,10 +221,14 @@ pub struct ResponseHit {
 
 #[derive(Deserialize)]
 pub struct ResponseSource {
+    #[serde(default = "String::default")]
     pub title: String,
     pub locale: Locale,
+    #[serde(default = "String::default")]
     pub slug: String,
+    #[serde(default = "f64::default")]
     pub popularity: f64,
+    #[serde(default = "String::default")]
     pub summary: String,
 }
 


### PR DESCRIPTION
Fixes https://sentry.io/organizations/mozilla/issues/3517135137/?query=is%3Aunresolved

I reckon it's probably best to be a bit more flexible in how we parse elastic responses, even with the fix in https://github.com/mdn/yari/pull/6934.