### PR TITLE
fix(workflows): print deploy command with correct revision

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Print staging deploy command
-        run: echo "::notice Prod deploy run - helm template --set rev=${{ steps.meta.outputs.tags }} -f k8s/values.yaml -f k8s/values/stage.yaml k8s | kubectl apply -f -"
+        run: echo "::notice Prod deploy run - helm template --set rev=${{ steps.vars.outputs.sha_short }} -f k8s/values.yaml -f k8s/values/stage.yaml k8s | kubectl apply -f -"
 
       - name: Print production deploy command
-        run: echo "::notice Prod deploy - helm template --set rev=${{ steps.meta.outputs.tags }} -f k8s/values.yaml -f k8s/values/prod.yaml k8s | kubectl apply -f -"
+        run: echo "::notice Prod deploy - helm template --set rev=${{ steps.vars.outputs.sha_short }} -f k8s/values.yaml -f k8s/values/prod.yaml k8s | kubectl apply -f -"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,9 +11,11 @@ env:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -24,9 +26,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"   
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -34,6 +38,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=,suffix=,format=short
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -41,7 +46,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
       - name: Print staging deploy command
         run: echo "::notice Prod deploy run - helm template --set rev=${{ steps.meta.outputs.tags }} -f k8s/values.yaml -f k8s/values/stage.yaml k8s | kubectl apply -f -"
+
       - name: Print production deploy command
         run: echo "::notice Prod deploy - helm template --set rev=${{ steps.meta.outputs.tags }} -f k8s/values.yaml -f k8s/values/prod.yaml k8s | kubectl apply -f -"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Print staging deploy command
-        run: echo "::notice Prod deploy run - helm template --set rev=${{ steps.vars.outputs.sha_short }} -f k8s/values.yaml -f k8s/values/stage.yaml k8s | kubectl apply -f -"
+        run: echo "helm template --set rev=${{ steps.vars.outputs.sha_short }} -f k8s/values.yaml -f k8s/values/stage.yaml k8s | kubectl apply -f -"
 
       - name: Print production deploy command
-        run: echo "::notice Prod deploy - helm template --set rev=${{ steps.vars.outputs.sha_short }} -f k8s/values.yaml -f k8s/values/prod.yaml k8s | kubectl apply -f -"
+        run: echo "helm template --set rev=${{ steps.vars.outputs.sha_short }} -f k8s/values.yaml -f k8s/values/prod.yaml k8s | kubectl apply -f -"


### PR DESCRIPTION
@Guyzeroth pointed out to me that the deploy command as printed in the docker-build workflow is not correct, as the `rev=` parameter should really just contain the docker tag, not the fully qualified docker image url.

- Bad: https://github.com/mdn/rumba/runs/7971113562?check_suite_focus=true#step:7:8
- Good: https://github.com/mdn/rumba/runs/7979460965?check_suite_focus=true#step:5:8

This PR:
- adds newlines in the workflow to make it more readable,
- removes `ghcr.io/mdn/rumba:` prefix from the `rev` parameter, and
- strips unnecessary output before the deploy command to make it easier to copy.