### PR TITLE
MP-139: rename auth_cookie_key to cookie_key

### DIFF
--- a/.settings.local.toml
+++ b/.settings.local.toml
@@ -12,7 +12,7 @@ scopes = "openid profile email profile:subscriptions"
 auth_cookie_name = "auth-cookie"
 login_cookie_name = "login-cookie"
 auth_cookie_secure = false
-auth_cookie_key = "DUwIFZuUYzRhHPlhOm6DwTHSDUSyR5SyvZHIeHdx4DIanxm5/GD/4dqXROLvn5vMofOYUq37HhhivjCyMCWP4w=="
+cookie_key = "DUwIFZuUYzRhHPlhOm6DwTHSDUSyR5SyvZHIeHdx4DIanxm5/GD/4dqXROLvn5vMofOYUq37HhhivjCyMCWP4w=="
 admin_update_bearer_token="TEST_TOKEN"
 
 [application]

--- a/.settings.test.toml
+++ b/.settings.test.toml
@@ -14,7 +14,7 @@ login_cookie_name = "login-cookie"
 auth_cookie_secure = false
 client_id="TEST_CLIENT_ID"
 client_secret="TEST_CLIENT_SECRET"
-auth_cookie_key = "DUwIFZuUYzRhHPlhOm6DwTHSDUSyR5SyvZHIeHdx4DIanxm5/GD/4dqXROLvn5vMofOYUq37HhhivjCyMCWP4w=="
+cookie_key = "DUwIFZuUYzRhHPlhOm6DwTHSDUSyR5SyvZHIeHdx4DIanxm5/GD/4dqXROLvn5vMofOYUq37HhhivjCyMCWP4w=="
 admin_update_bearer_token="TEST_TOKEN"
 
 [application]

--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: MDN__{{ $key | upper }}
               value: "{{ $value }}"
             {{- end }}
-            {{- range list "db__uri" "auth__admin_update_bearer_token" "auth__auth_cookie_key" "auth__client_secret" "search__url" "sentry__dsn"}}
+            {{- range list "db__uri" "auth__admin_update_bearer_token" "auth__cookie_key" "auth__client_secret" "search__url" "sentry__dsn"}}
             - name: MDN__{{ . }}
               valueFrom:
                 secretKeyRef:

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -50,7 +50,7 @@ impl TryFrom<Cookie<'static>> for LoginCookie {
         let mut jar = CookieJar::new();
         jar.add_original(cookie);
         match jar
-            .private_mut(&Key::derive_from(&SETTINGS.auth.auth_cookie_key))
+            .private_mut(&Key::derive_from(&SETTINGS.auth.cookie_key))
             .get(&SETTINGS.auth.login_cookie_name)
         {
             Some(cookie) => {
@@ -77,7 +77,7 @@ impl TryFrom<LoginCookie> for Cookie<'static> {
         .path("/")
         .finish();
         let mut jar = CookieJar::new();
-        jar.private_mut(&Key::derive_from(&SETTINGS.auth.auth_cookie_key))
+        jar.private_mut(&Key::derive_from(&SETTINGS.auth.cookie_key))
             .add(cookie);
         match jar.get(&SETTINGS.auth.login_cookie_name) {
             Some(cookie) => Ok(cookie.to_owned()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
         })
     };
 
-    let session_cookie_key = Key::derive_from(&SETTINGS.auth.auth_cookie_key);
+    let session_cookie_key = Key::derive_from(&SETTINGS.auth.cookie_key);
 
     HttpServer::new(move || {
         let app = App::new()

--- a/src/session_migration_middleware.rs
+++ b/src/session_migration_middleware.rs
@@ -50,7 +50,7 @@ where
             let mut jar = CookieJar::new();
             jar.add_original(auth_cookie);
             if let Some(verified_decoded) = jar
-                .private(&Key::derive_from(&SETTINGS.auth.auth_cookie_key))
+                .private(&Key::derive_from(&SETTINGS.auth.cookie_key))
                 .get(&SETTINGS.auth.auth_cookie_name)
             {
                 let session = req.get_session();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,7 +30,7 @@ pub struct Auth {
     pub login_cookie_name: String,
     pub auth_cookie_secure: bool,
     #[serde_as(as = "Base64")]
-    pub auth_cookie_key: [u8; 64],
+    pub cookie_key: [u8; 64],
     pub admin_update_bearer_token: String,
 }
 

--- a/tests/api/whoami.rs
+++ b/tests/api/whoami.rs
@@ -65,7 +65,7 @@ async fn whoami_legacy_logged_in_test() -> Result<(), Error> {
     let mut cookies = CookieJar::new();
     cookies.add(Cookie::parse_encoded(set_cookie.to_str()?.to_owned())?);
     let cookie = cookies
-        .private(&Key::derive_from(&SETTINGS.auth.auth_cookie_key))
+        .private(&Key::derive_from(&SETTINGS.auth.cookie_key))
         .get(&SETTINGS.auth.auth_cookie_name)
         .unwrap();
     assert_eq!(

--- a/tests/helpers/app.rs
+++ b/tests/helpers/app.rs
@@ -62,7 +62,7 @@ pub async fn test_app_with_login(
     init_logging();
     let arbiter = Arbiter::new();
     let arbiter_handle = Data::new(arbiter.handle());
-    let session_cookie_key = Key::derive_from(&SETTINGS.auth.auth_cookie_key);
+    let session_cookie_key = Key::derive_from(&SETTINGS.auth.cookie_key);
 
     let app = App::new()
         .wrap(error_handler())

--- a/tests/helpers/http_client.rs
+++ b/tests/helpers/http_client.rs
@@ -72,7 +72,7 @@ impl<T: Service<Request, Response = RumbaTestResponse, Error = Error>> TestHttpC
     pub fn with_legacy_session(service: T, id: &'static str) -> Self {
         let mut cookie_jar = CookieJar::new();
         cookie_jar
-            .private_mut(&Key::derive_from(&SETTINGS.auth.auth_cookie_key))
+            .private_mut(&Key::derive_from(&SETTINGS.auth.cookie_key))
             .add(Cookie::new("auth-cookie", id));
 
         Self {


### PR DESCRIPTION
since we use it for both the auth and login cookies
