### PR TITLE
MP-137: fix: items from deleted collection showing as saved

### DIFF
--- a/src/db/v2/multiple_collections.rs
+++ b/src/db/v2/multiple_collections.rs
@@ -279,12 +279,13 @@ pub fn get_collections_and_items_containing_url(
 ) -> Result<Vec<(i64, CollectionItemAndDocumentQuery)>, DbError> {
     Ok(schema::collection_items::table
         .inner_join(schema::documents::table)
+        .inner_join(schema::multiple_collections::table)
         .filter(
-            schema::documents::uri.eq(normalize_uri(url)).and(
-                schema::collection_items::deleted_at
-                    .is_null()
-                    .and(schema::collection_items::user_id.eq(user.id)),
-            ),
+            schema::documents::uri
+                .eq(normalize_uri(url))
+                .and(schema::collection_items::user_id.eq(user.id))
+                .and(schema::collection_items::deleted_at.is_null())
+                .and(schema::multiple_collections::deleted_at.is_null()),
         )
         .select((
             (schema::collection_items::multiple_collection_id),


### PR DESCRIPTION
This is the easier change, but perhaps the better one is to set the `collection_items::deleted_at` value for each item when deleting a collection, and add a migration to add those for already deleted collections?