### PR TITLE
prepare for diesel 2.0.3

### DIFF
--- a/migrations/2022-07-19-114928_cascade/down.sql
+++ b/migrations/2022-07-19-114928_cascade/down.sql
@@ -1,23 +1,8 @@
-BEGIN;
-ALTER TABLE collections DROP CONSTRAINT collections_user_id_fkey;
-ALTER TABLE collections ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE NO ACTION;
-COMMIT;
-
-BEGIN;
-ALTER TABLE settings DROP CONSTRAINT settings_user_id_fkey;
-ALTER TABLE settings ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE NO ACTION;
-COMMIT;
-
-BEGIN;
-ALTER TABLE watched_items DROP CONSTRAINT watched_items_user_id_fkey;
-ALTER TABLE watched_items ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE NO ACTION;
-COMMIT;
-
-BEGIN;
-ALTER TABLE notifications DROP CONSTRAINT notifications_user_id_fkey;
-ALTER TABLE notifications ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE NO ACTION;
-COMMIT;
+ALTER TABLE collections DROP CONSTRAINT collections_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE NO ACTION;
+ALTER TABLE settings DROP CONSTRAINT settings_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE NO ACTION;
+ALTER TABLE watched_items DROP CONSTRAINT watched_items_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE NO ACTION;
+ALTER TABLE notifications DROP CONSTRAINT notifications_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE NO ACTION;

--- a/migrations/2022-07-19-114928_cascade/up.sql
+++ b/migrations/2022-07-19-114928_cascade/up.sql
@@ -1,23 +1,8 @@
-BEGIN;
-ALTER TABLE collections DROP CONSTRAINT collections_user_id_fkey;
-ALTER TABLE collections ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE CASCADE;
-COMMIT;
-
-BEGIN;
-ALTER TABLE settings DROP CONSTRAINT settings_user_id_fkey;
-ALTER TABLE settings ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE CASCADE;
-COMMIT;
-
-BEGIN;
-ALTER TABLE watched_items DROP CONSTRAINT watched_items_user_id_fkey;
-ALTER TABLE watched_items ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE CASCADE;
-COMMIT;
-
-BEGIN;
-ALTER TABLE notifications DROP CONSTRAINT notifications_user_id_fkey;
-ALTER TABLE notifications ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE CASCADE;
-COMMIT;
+ALTER TABLE collections DROP CONSTRAINT collections_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE settings DROP CONSTRAINT settings_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE watched_items DROP CONSTRAINT watched_items_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE notifications DROP CONSTRAINT notifications_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/migrations/2023-01-17-155729_ping-cascade/down.sql
+++ b/migrations/2023-01-17-155729_ping-cascade/down.sql
@@ -1,5 +1,2 @@
-BEGIN;
-ALTER TABLE activity_pings DROP CONSTRAINT activity_pings_user_id_fkey;
-ALTER TABLE activity_pings ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE NO ACTION;
-COMMIT;
+ALTER TABLE activity_pings DROP CONSTRAINT activity_pings_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE NO ACTION;

--- a/migrations/2023-01-17-155729_ping-cascade/up.sql
+++ b/migrations/2023-01-17-155729_ping-cascade/up.sql
@@ -1,5 +1,2 @@
-BEGIN;
-ALTER TABLE activity_pings DROP CONSTRAINT activity_pings_user_id_fkey;
-ALTER TABLE activity_pings ADD FOREIGN KEY (user_id)
-REFERENCES users(id) ON DELETE CASCADE;
-COMMIT;
+ALTER TABLE activity_pings DROP CONSTRAINT activity_pings_user_id_fkey,
+    ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/tests/helpers/db.rs
+++ b/tests/helpers/db.rs
@@ -18,8 +18,15 @@ pub fn reset() -> Result<Pool, Error> {
     connection
         .revert_all_migrations(MIGRATIONS)
         .expect("failed to revert migrations");
+
     connection
         .run_pending_migrations(MIGRATIONS)
         .expect("failed to run migrations");
     Ok(pool)
+}
+
+#[test]
+fn test_reset() -> Result<(), Error> {
+    reset()?;
+    Ok(())
 }


### PR DESCRIPTION
run `cargo udpate -p diesel` and run test to see the issue. I haven't 100% figured out the root cause within diesel but looked at crates.io (https://github.com/rust-lang/crates.io/blob/master/migrations/20170708133715_ensure_crate_id_foreign_keys_cascade/up.sql)