### PR TITLE
User and migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ RUN apt-get update && apt-get install -y \
     libpq5 ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /root/
+RUN groupadd rumba && useradd -g rumba rumba
+
+WORKDIR /app/
 COPY --from=0 /usr/src/rumba/target/release/rumba .
+RUN chown -R rumba:rumba /app
+USER rumba
 
 CMD ["./rumba"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pool = db::establish_connection(&SETTINGS.db.uri);
 
-    if let Some(true) = SETTINGS.skip_migrations {
+    if SETTINGS.skip_migrations {
         info!("skipping migrations...")
     } else {
         info!("running migrations...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,13 @@ async fn main() -> anyhow::Result<()> {
     debug!("DEBUG logging enabled");
 
     let pool = db::establish_connection(&SETTINGS.db.uri);
-    pool.get()?
-        .run_pending_migrations(MIGRATIONS)
-        .expect("failed to run migrations");
+
+    if !SETTINGS.skip_migrations {
+        pool.get()?
+            .run_pending_migrations(MIGRATIONS)
+            .expect("failed to run migrations");
+    }
+
     let pool = Data::new(pool);
 
     let http_client = Data::new(HttpClient::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,13 +40,17 @@ async fn main() -> anyhow::Result<()> {
     if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "info");
     }
+
     init_logging(!SETTINGS.logging.human_logs);
     info!("starting…");
     debug!("DEBUG logging enabled");
 
     let pool = db::establish_connection(&SETTINGS.db.uri);
 
-    if !SETTINGS.skip_migrations {
+    if let Some(true) = SETTINGS.skip_migrations {
+        info!("skipping migrations...")
+    } else {
+        info!("running migrations...");
         pool.get()?
             .run_pending_migrations(MIGRATIONS)
             .expect("failed to run migrations");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,7 +86,7 @@ pub struct Settings {
     pub metrics: Metrics,
     pub sentry: Option<Sentry>,
     pub basket: Option<Basket>,
-    pub skip_migrations: bool,
+    pub skip_migrations: Option<bool>,
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,7 +86,8 @@ pub struct Settings {
     pub metrics: Metrics,
     pub sentry: Option<Sentry>,
     pub basket: Option<Basket>,
-    pub skip_migrations: Option<bool>,
+   #[serde(default)]
+    pub skip_migrations: bool,
 }
 
 impl Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,7 +86,7 @@ pub struct Settings {
     pub metrics: Metrics,
     pub sentry: Option<Sentry>,
     pub basket: Option<Basket>,
-   #[serde(default)]
+    #[serde(default)]
     pub skip_migrations: bool,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,7 @@ pub struct Settings {
     pub metrics: Metrics,
     pub sentry: Option<Sentry>,
     pub basket: Option<Basket>,
+    pub skip_migrations: bool,
 }
 
 impl Settings {


### PR DESCRIPTION
Two commits here to help us with our migration.

1. Allows us to skip migrations. This lets us spin up rumba in an environment where we are still replicating data and then allows us to switch once that replica is promoted.
2. In our new environment we cannot run as `root`, this allows us to run rumba as the rumba user instead.