### PR TITLE
chore(whoami): capture error with sentry

### DIFF
--- a/src/api/whoami.rs
+++ b/src/api/whoami.rs
@@ -83,8 +83,9 @@ pub async fn whoami(
                     metrics.incr("whoami.logged_in_success");
                     Ok(HttpResponse::Ok().json(response))
                 }
-                Err(_err) => {
+                Err(err) => {
                     metrics.incr("whoami.logged_in_invalid");
+                    sentry::capture_error(&err);
                     Err(ApiError::InvalidSession)
                 }
             }


### PR DESCRIPTION
This should shed some light as to why the `/api/v1/whoami` request are failing with an existing `auth-cookie`.