### PR TITLE
Bump diesel_derive from 2.0.1 to 2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b758c91dbc3fe1fdcb0dba5bd13276c6a66422f2ef5795b58488248a310aa"
+checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",


### PR DESCRIPTION
This should unblock https://github.com/mdn/rumba/pull/178.