### PR TITLE
ci: add release-please workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps): "
+      prefix-development: "build(dev-deps): "

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    if: github.repository == 'mdn/rumba'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: rust
+          package-name: release-please-action

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "rumba"
-version = "0.0.1"
+version = "1.0.0"
 dependencies = [
  "actix-http",
  "actix-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rumba"
-version = "0.0.1"
+version = "1.0.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
This workflow opens a release PR with changelog changes as soon as the action finds commits since the last tag (that adhere to conventional commits). Merging the PR will trigger the action to tag the merge commit accordingly.

See: https://github.com/google-github-actions/release-please-action#setting-up-this-action

(MP-346)