### PR TITLE
enhance(ai-help): add title to context

### DIFF
--- a/src/ai/ask.rs
+++ b/src/ai/ask.rs
@@ -82,7 +82,10 @@ pub async fn prepare_ask_req(
         if token_len >= 1500 {
             break;
         }
-        context.push(doc.content);
+        context.push(format!(
+            "Excerpt from MDN article \"{}\":\n{}",
+            doc.title, doc.content
+        ));
         if !refs.iter().any(|r: &RefDoc| r.slug == doc.slug) {
             refs.push(RefDoc {
                 url: doc.url,


### PR DESCRIPTION
GPT was lacking context and got confuses with section to use. Therefore, we add the document title above each section.