### PR TITLE
enhance(release-please): take enhance/chore commits into consideration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,10 @@ jobs:
         with:
           release-type: rust
           package-name: release-please-action
+          changelog-types: |
+            [
+              {"type": "feat", "section": "Features", "hidden": false},
+              {"type": "fix", "section": "Bug Fixes", "hidden": false},
+              {"type": "enhance", "section": "Enhancements", "hidden": false},
+              {"type": "chore", "section": "Miscellaneous", "hidden": false}
+            ]


### PR DESCRIPTION
We use `enhance:` and `chore:` prefixes for commits, but these don't trigger release-please PRs.