### PR TITLE
chore(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# ----------------------------------------------------------------------------
+# MDN Rumba CODEOWNERS
+# ----------------------------------------------------------------------------
+# Order is important. The last matching pattern takes precedence.
+# For more detailed information, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# DEFAULT OWNERS
+# ----------------------------------------------------------------------------
+*    @mdn/core-dev
+
+# These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
+# If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
+/Cargo.lock @mdn-bot
+/Cargo.toml @mdn-bot


### PR DESCRIPTION
Adds `CODEOWNERS` file to ensure reviewers are assigned to every PR.