### PR TITLE
fix(tests): add 10ms delay after we are done with stubr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,6 +3736,7 @@ dependencies = [
  "stubr-attributes",
  "thiserror",
  "tiktoken-rs",
+ "tokio",
  "url",
  "uuid",
  "validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,4 @@ sha2 = "0.10"
 stubr = "0.6"
 stubr-attributes = "0.6"
 assert-json-diff = "2"
+tokio = { version = "1", features = ["io-util"] }

--- a/tests/api/ai_explain.rs
+++ b/tests/api/ai_explain.rs
@@ -1,6 +1,5 @@
-use crate::helpers::app::test_app_with_login;
+use crate::helpers::app::{drop_stubr, test_app_with_login};
 use crate::helpers::db::{get_pool, reset};
-use crate::helpers::wait_for_stubr;
 use actix_web::test;
 use anyhow::Error;
 use diesel::{QueryDsl, RunQueryDsl};
@@ -49,7 +48,6 @@ fn add_explain_cache() -> Result<(), Error> {
 async fn test_explain() -> Result<(), Error> {
     let pool = reset()?;
     add_explain_cache()?;
-    wait_for_stubr().await?;
     let app = test_app_with_login(&pool).await.unwrap();
     let service = test::init_service(app).await;
     let request = test::TestRequest::post()
@@ -123,7 +121,6 @@ async fn test_explain() -> Result<(), Error> {
         .first(&mut conn)?;
     assert_eq!(row.thumbs_up, 1);
     assert_eq!(row.thumbs_down, 1);
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/ai_help.rs
+++ b/tests/api/ai_help.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::helpers::api_assertions::assert_ok_with_json_containing;
-use crate::helpers::app::init_test;
+use crate::helpers::app::{drop_stubr, init_test};
 use actix_http::StatusCode;
 use actix_rt::time::sleep;
 use anyhow::Error;
@@ -58,7 +58,7 @@ async fn test_quota() -> Result<(), Error> {
         )
         .await;
     assert_eq!(ai_help.status(), StatusCode::PAYMENT_REQUIRED);
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -142,6 +142,6 @@ async fn test_quota_rest() -> Result<(), Error> {
     assert_eq!(ai_help.status(), StatusCode::NOT_IMPLEMENTED);
     let quota = client.get("/api/v1/plus/ai/ask/quota", None).await;
     assert_ok_with_json_containing(quota, json!({"quota": { "count": 1, "limit": 5}})).await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/ai_help_history.rs
+++ b/tests/api/ai_help_history.rs
@@ -1,7 +1,6 @@
-use crate::helpers::app::test_app_with_login;
+use crate::helpers::app::{drop_stubr, test_app_with_login};
 use crate::helpers::db::{get_pool, reset};
 use crate::helpers::http_client::TestHttpClient;
-use crate::helpers::wait_for_stubr;
 use actix_web::test;
 use anyhow::Error;
 use async_openai::types::ChatCompletionRequestMessage;
@@ -64,7 +63,6 @@ fn add_history_log() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn test_history() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
     let app = test_app_with_login(&pool).await.unwrap();
     let service = test::init_service(app).await;
     let mut logged_in_client = TestHttpClient::new(service).await;
@@ -93,8 +91,7 @@ async fn test_history() -> Result<(), Error> {
             test::read_body(history).await.as_ref()
         ))
     );
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 

--- a/tests/api/auth.rs
+++ b/tests/api/auth.rs
@@ -4,14 +4,15 @@ use actix_web::test;
 use anyhow::Error;
 use url::Url;
 
-use crate::helpers::{app::test_app_with_login, db::reset, http_client::check_stubr_initialized};
+use crate::helpers::{
+    app::{drop_stubr, test_app_with_login},
+    db::reset,
+};
 
 #[actix_rt::test]
 #[stubr::mock(port = 4321)]
 async fn test_next() -> Result<(), Error> {
     let pool = reset()?;
-    let _stubr_ok = check_stubr_initialized().await;
-
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
 
@@ -53,5 +54,6 @@ async fn test_next() -> Result<(), Error> {
             .and_then(|l| l.to_str().ok()),
         Some("http://localhost:8000/foo")
     );
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/fxa_webhooks.rs
+++ b/tests/api/fxa_webhooks.rs
@@ -1,12 +1,12 @@
 use std::thread;
 use std::time::Duration;
 
+use crate::helpers::app::drop_stubr;
 use crate::helpers::app::test_app_with_login;
 use crate::helpers::db::reset;
 use crate::helpers::http_client::PostPayload;
 use crate::helpers::http_client::TestHttpClient;
 use crate::helpers::read_json;
-use crate::helpers::wait_for_stubr;
 use actix_http::StatusCode;
 use actix_web::test;
 use anyhow::anyhow;
@@ -19,6 +19,7 @@ use rumba::db::types::FxaEventStatus;
 use rumba::db::Pool;
 use serde_json::json;
 use stubr::{Config, Stubr};
+use tokio::time::sleep;
 
 const TEN_MS: std::time::Duration = Duration::from_millis(10);
 
@@ -68,7 +69,6 @@ async fn subscription_state_change_to_10m_test() -> Result<(), Error> {
     let set_token =
         include_str!("../data/set_tokens/set_token_subscription_state_change_to_10m.txt");
     let pool = reset()?;
-    wait_for_stubr().await?;
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
     let mut logged_in_client = TestHttpClient::new(service).await;
@@ -111,8 +111,7 @@ async fn subscription_state_change_to_10m_test() -> Result<(), Error> {
         FxaEvent::SubscriptionStateChange,
         FxaEventStatus::Ignored,
     )?;
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -121,7 +120,9 @@ async fn subscription_state_change_to_10m_test() -> Result<(), Error> {
 async fn subscription_state_change_to_core_test_empty_subscription() -> Result<(), Error> {
     let set_token =
         include_str!("../data/set_tokens/set_token_subscription_state_change_to_core.txt");
-    subscription_state_change_to_core_test(set_token).await
+    subscription_state_change_to_core_test(set_token).await?;
+    drop_stubr(stubr).await;
+    Ok(())
 }
 
 #[actix_rt::test]
@@ -129,12 +130,13 @@ async fn subscription_state_change_to_core_test_empty_subscription() -> Result<(
 async fn subscription_state_change_to_core_test_inactive() -> Result<(), Error> {
     let set_token =
         include_str!("../data/set_tokens/set_token_subscription_state_change_to_core_inactive.txt");
-    subscription_state_change_to_core_test(set_token).await
+    subscription_state_change_to_core_test(set_token).await?;
+    drop_stubr(stubr).await;
+    Ok(())
 }
 
 async fn subscription_state_change_to_core_test(set_token: &str) -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
     let mut logged_in_client = TestHttpClient::new(service).await;
@@ -167,14 +169,11 @@ async fn subscription_state_change_to_core_test(set_token: &str) -> Result<(), E
         FxaEvent::SubscriptionStateChange,
         FxaEventStatus::Processed,
     )?;
-
     Ok(())
 }
 
 #[actix_rt::test]
 async fn delete_user_test() -> Result<(), Error> {
-    let set_token = include_str!("../data/set_tokens/set_token_delete_user.txt");
-    let pool = reset()?;
     let stubr = Stubr::start_blocking_with(
         vec!["tests/stubs", "tests/test_specific_stubs/collections"],
         Config {
@@ -185,7 +184,8 @@ async fn delete_user_test() -> Result<(), Error> {
             verify: false,
         },
     );
-    wait_for_stubr().await?;
+    let set_token = include_str!("../data/set_tokens/set_token_delete_user.txt");
+    let pool = reset()?;
 
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
@@ -248,8 +248,7 @@ async fn delete_user_test() -> Result<(), Error> {
         FxaEvent::DeleteUser,
         FxaEventStatus::Processed,
     )?;
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -258,7 +257,6 @@ async fn delete_user_test() -> Result<(), Error> {
 async fn invalid_set_test() -> Result<(), Error> {
     let set_token = include_str!("../data/set_tokens/set_token_delete_user_invalid.txt");
     let pool = reset()?;
-    wait_for_stubr().await?;
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
     let mut logged_in_client = TestHttpClient::new(service).await;
@@ -280,29 +278,21 @@ async fn invalid_set_test() -> Result<(), Error> {
         .select(schema::raw_webhook_events_tokens::token)
         .first::<String>(&mut conn)?;
     assert_eq!(failed_token, set_token);
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
-async fn change_profile_test() -> Result<(), Error> {
-    let stubr = Stubr::start_blocking_with(
-        vec!["tests/stubs"],
-        Config {
-            port: Some(4321),
-            latency: None,
-            global_delay: None,
-            verbose: true,
-            verify: false,
-        },
-    );
-    wait_for_stubr().await?;
-
+#[stubr::mock(port = 4321)]
+async fn whoami_test() -> Result<(), Error> {
     let set_token = include_str!("../data/set_tokens/set_token_profile_change.txt");
     let pool = reset()?;
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
     let mut logged_in_client = TestHttpClient::new(service).await;
+    let res = logged_in_client.trigger_webhook(set_token).await;
+    assert!(res.response().status().is_success());
+
     let whoami = logged_in_client
         .get("/api/v1/whoami", Some(vec![("X-Appengine-Country", "IS")]))
         .await;
@@ -310,9 +300,12 @@ async fn change_profile_test() -> Result<(), Error> {
     let json = read_json(whoami).await;
     assert_eq!(json["username"], "TEST_SUB");
     assert_eq!(json["email"], "test@test.com");
+    drop_stubr(stubr).await;
+    Ok(())
+}
 
-    drop(stubr);
-
+#[actix_rt::test]
+async fn change_profile_test() -> Result<(), Error> {
     let stubr = Stubr::start_blocking_with(
         vec!["tests/stubs", "tests/test_specific_stubs/fxa_webhooks"],
         Config {
@@ -323,9 +316,11 @@ async fn change_profile_test() -> Result<(), Error> {
             verify: false,
         },
     );
-    wait_for_stubr().await?;
-
-    thread::sleep(TEN_MS);
+    let set_token = include_str!("../data/set_tokens/set_token_profile_change.txt");
+    let pool = reset()?;
+    let app = test_app_with_login(&pool).await?;
+    let service = test::init_service(app).await;
+    let mut logged_in_client = TestHttpClient::new(service).await;
 
     let res = logged_in_client.trigger_webhook(set_token).await;
     assert!(res.response().status().is_success());
@@ -341,7 +336,7 @@ async fn change_profile_test() -> Result<(), Error> {
         if json["email"] == "foo@bar.com" {
             break;
         }
-        thread::sleep(TEN_MS);
+        sleep(TEN_MS).await;
         tries -= 1;
     }
 
@@ -355,7 +350,6 @@ async fn change_profile_test() -> Result<(), Error> {
         FxaEvent::ProfileChange,
         FxaEventStatus::Processed,
     )?;
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/fxa_webhooks.rs
+++ b/tests/api/fxa_webhooks.rs
@@ -283,8 +283,17 @@ async fn invalid_set_test() -> Result<(), Error> {
 }
 
 #[actix_rt::test]
-#[stubr::mock(port = 4321)]
 async fn whoami_test() -> Result<(), Error> {
+    let stubr = Stubr::start_blocking_with(
+        vec!["tests/stubs"],
+        Config {
+            port: Some(4321),
+            latency: None,
+            global_delay: None,
+            verbose: true,
+            verify: false,
+        },
+    );
     let set_token = include_str!("../data/set_tokens/set_token_profile_change.txt");
     let pool = reset()?;
     let app = test_app_with_login(&pool).await?;
@@ -301,11 +310,7 @@ async fn whoami_test() -> Result<(), Error> {
     assert_eq!(json["username"], "TEST_SUB");
     assert_eq!(json["email"], "test@test.com");
     drop_stubr(stubr).await;
-    Ok(())
-}
 
-#[actix_rt::test]
-async fn change_profile_test() -> Result<(), Error> {
     let stubr = Stubr::start_blocking_with(
         vec!["tests/stubs", "tests/test_specific_stubs/fxa_webhooks"],
         Config {

--- a/tests/api/multiple_collections.rs
+++ b/tests/api/multiple_collections.rs
@@ -3,7 +3,7 @@ use crate::helpers::api_assertions::{
     assert_conflict_with_json_containing, assert_created, assert_created_returning_json,
     assert_created_with_json_containing, assert_ok, assert_ok_with_json_containing,
 };
-use crate::helpers::app::init_test;
+use crate::helpers::app::{drop_stubr, init_test};
 use crate::helpers::http_client::PostPayload;
 use crate::helpers::read_json;
 
@@ -61,7 +61,7 @@ async fn test_create_and_get_collection() -> Result<(), Error> {
         ),
     )
     .await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -152,8 +152,7 @@ async fn test_add_items_to_collection() -> Result<(), Error> {
         }),
     )
     .await;
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -216,7 +215,7 @@ async fn test_collection_name_conflicts() -> Result<(), Error> {
         )
         .await;
     assert_created_with_json_containing(res, json!({"name":"Test 2"})).await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -297,7 +296,7 @@ async fn test_collection_item_conflicts() -> Result<(), Error> {
         }),
     )
     .await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -366,7 +365,7 @@ async fn test_edit_item_in_collection() -> Result<(), Error> {
         }),
     )
     .await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -424,8 +423,7 @@ async fn test_delete_item_in_collection() -> Result<(), Error> {
         json!({"id": collection_1,"article_count": 0, "items": []}),
     )
     .await;
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -510,7 +508,7 @@ async fn test_delete_collection() -> Result<(), Error> {
         .await;
 
     assert_created(res);
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -562,14 +560,13 @@ async fn test_no_modify_delete_default() -> Result<(), Error> {
         json!({"error": "Cannot delete default collection"}),
     )
     .await;
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
 async fn test_long_collection_name_is_bad_request() -> Result<(), Error> {
-    let (mut client, _stubr) =
+    let (mut client, stubr) =
         init_test(vec!["tests/stubs", "tests/test_specific_stubs/collections"]).await?;
     let base_url = "/api/v2/collections/";
     let two_hundred_twenty = "This is a really long title that has over 1024 characeters 5 times this is 1100. What were we thinking creeating such a long title really? 1024 really is a lot of character. To make this easier let's repeat this 5 times.".to_owned();
@@ -588,12 +585,13 @@ async fn test_long_collection_name_is_bad_request() -> Result<(), Error> {
         )
         .await;
     assert_bad_request_with_json_containing(res, json!({"code":400,"error":"Validation Error","message":"Error validating input name: 'name' must be between 1 and 1024 chars"})).await;
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
 async fn test_very_long_collection_description_is_bad_request() -> Result<(), Error> {
-    let (mut client, _stubr) =
+    let (mut client, stubr) =
         init_test(vec!["tests/stubs", "tests/test_specific_stubs/collections"]).await?;
     let base_url = "/api/v2/collections/";
 
@@ -614,12 +612,13 @@ async fn test_very_long_collection_description_is_bad_request() -> Result<(), Er
         )
         .await;
     assert_bad_request_with_json_containing(res, json!({"code":400,"error":"Validation Error","message":"Error validating input description: 'description' must not be longer than 65536 chars"})).await;
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
 async fn test_long_collection_item_title_is_bad_request() -> Result<(), Error> {
-    let (mut client, _stubr) =
+    let (mut client, stubr) =
         init_test(vec!["tests/stubs", "tests/test_specific_stubs/collections"]).await?;
     let base_url = "/api/v2/collections/";
 
@@ -653,12 +652,13 @@ async fn test_long_collection_item_title_is_bad_request() -> Result<(), Error> {
         )
         .await;
     assert_bad_request_with_json_containing(res, json!({"code":400,"error":"Validation Error","message":"Error validating input title: 'title' must be between 1 and 1024 chars"})).await;
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
 async fn test_very_long_collection_item_notes_is_bad_request() -> Result<(), Error> {
-    let (mut client, _stubr) =
+    let (mut client, stubr) =
         init_test(vec!["tests/stubs", "tests/test_specific_stubs/collections"]).await?;
     let base_url = "/api/v2/collections/";
 
@@ -699,12 +699,13 @@ async fn test_very_long_collection_item_notes_is_bad_request() -> Result<(), Err
         )
         .await;
     assert_bad_request_with_json_containing(res, json!({"code":400,"error":"Validation Error","message":"Error validating input notes: 'notes' must not be longer than 65536 chars"})).await;
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
 async fn test_collection_subscription_limits() -> Result<(), Error> {
-    let (mut client, _stubr) = init_test(vec![
+    let (mut client, stubr) = init_test(vec![
         "tests/stubs",
         "tests/test_specific_stubs/collections",
         "tests/test_specific_stubs/collections_core_user",
@@ -765,13 +766,13 @@ async fn test_collection_subscription_limits() -> Result<(), Error> {
         )
         .await;
     assert_created(res);
-    drop(_stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
 #[actix_rt::test]
 async fn test_paying_user_no_collection_limit() -> Result<(), Error> {
-    let (mut client, _stubr) =
+    let (mut client, stubr) =
         init_test(vec!["tests/stubs", "tests/test_specific_stubs/collections"]).await?;
 
     let base_url = "/api/v2/collections/";
@@ -789,7 +790,7 @@ async fn test_paying_user_no_collection_limit() -> Result<(), Error> {
             .await;
         assert_created(res);
     }
-    drop(_stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 #[actix_rt::test]
@@ -854,7 +855,7 @@ async fn test_delete_collection_items_also_deleted() -> Result<(), Error> {
         )
         .await;
     assert_ok_with_json_containing(res, json!({"results": [] })).await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -905,13 +906,15 @@ async fn test_create_and_get_many_collections() -> Result<(), Error> {
     body.as_array().unwrap().iter().reduce(|acc, next| {
         let t1 = DateTime::parse_from_rfc3339(acc["created_at"].as_str().unwrap())
             .unwrap()
-            .timestamp_nanos();
+            .timestamp_nanos_opt()
+            .unwrap();
         let t2 = DateTime::parse_from_rfc3339(next["created_at"].as_str().unwrap())
             .unwrap()
-            .timestamp_nanos();
+            .timestamp_nanos_opt()
+            .unwrap();
         assert!(t1 < t2);
         next
     });
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/ping.rs
+++ b/tests/api/ping.rs
@@ -1,7 +1,6 @@
-use crate::helpers::app::test_app_with_login;
+use crate::helpers::app::{drop_stubr, test_app_with_login};
 use crate::helpers::db::reset;
 use crate::helpers::http_client::{PostPayload, TestHttpClient};
-use crate::helpers::wait_for_stubr;
 use actix_web::test;
 use anyhow::Error;
 use diesel::prelude::*;
@@ -12,7 +11,6 @@ use serde_json::{json, Value};
 #[stubr::mock(port = 4321)]
 async fn test_empty() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
@@ -28,8 +26,7 @@ async fn test_empty() -> Result<(), Error> {
         .select(schema::activity_pings::activity)
         .first::<Value>(&mut conn)?;
     assert_eq!(activity_data, json!({ "subscription_type": "mdn_plus_5m" }));
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -37,7 +34,6 @@ async fn test_empty() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn test_garbage() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
@@ -57,8 +53,7 @@ async fn test_garbage() -> Result<(), Error> {
         .select(schema::activity_pings::activity)
         .first::<Value>(&mut conn)?;
     assert_eq!(activity_data, json!({ "subscription_type": "mdn_plus_5m" }));
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -66,7 +61,6 @@ async fn test_garbage() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn test_offline_disabled() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
@@ -86,8 +80,7 @@ async fn test_offline_disabled() -> Result<(), Error> {
         .select(schema::activity_pings::activity)
         .first::<Value>(&mut conn)?;
     assert_eq!(activity_data, json!({ "subscription_type": "mdn_plus_5m" }));
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -95,7 +88,6 @@ async fn test_offline_disabled() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn test_offline_enabled() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
@@ -118,8 +110,7 @@ async fn test_offline_enabled() -> Result<(), Error> {
         activity_data,
         json!({ "subscription_type": "mdn_plus_5m", "offline": true })
     );
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -127,7 +118,6 @@ async fn test_offline_enabled() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn test_offline_upsert() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await?;
     let service = test::init_service(app).await;
@@ -189,7 +179,6 @@ async fn test_offline_upsert() -> Result<(), Error> {
         .count()
         .first::<i64>(&mut conn)?;
     assert_eq!(count, 1);
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/root.rs
+++ b/tests/api/root.rs
@@ -1,9 +1,9 @@
 use crate::helpers::api_assertions::{
     assert_created_with_json_containing, assert_ok_with_json_containing,
 };
+use crate::helpers::app::drop_stubr;
 use crate::helpers::db::{get_pool, reset};
 use crate::helpers::http_client::TestHttpClient;
-use crate::helpers::wait_for_stubr;
 use crate::helpers::{app::test_app_with_login, http_client::PostPayload};
 use actix_http::StatusCode;
 use actix_web::test;
@@ -16,7 +16,6 @@ use serde_json::json;
 #[stubr::mock(port = 4321)]
 async fn find_user() -> Result<(), Error> {
     reset()?;
-    wait_for_stubr().await?;
     let pool = get_pool();
     let mut conn = pool.get()?;
 
@@ -207,6 +206,6 @@ async fn find_user() -> Result<(), Error> {
         }),
     )
     .await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/api/search.rs
+++ b/tests/api/search.rs
@@ -1,5 +1,5 @@
+use crate::helpers::app::{drop_stubr, test_app_only_search};
 use crate::helpers::read_json;
-use crate::helpers::{app::test_app_only_search, wait_for_stubr};
 use actix_http::body::BoxBody;
 use actix_web::{http::header, test};
 use anyhow::Error;
@@ -16,12 +16,11 @@ async fn do_request(path: &str) -> Result<actix_web::dev::ServiceResponse<BoxBod
             latency: None,
         },
     );
-    wait_for_stubr().await?;
     let app = test_app_only_search().await;
     let service = test::init_service(app).await;
     let request = test::TestRequest::get().uri(path).to_request();
     let response = test::call_service(&service, request).await;
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(response)
 }
 

--- a/tests/api/settings.rs
+++ b/tests/api/settings.rs
@@ -1,4 +1,4 @@
-use crate::helpers::app::init_test;
+use crate::helpers::app::{drop_stubr, init_test};
 use crate::helpers::read_json;
 use anyhow::Error;
 use serde_json::json;
@@ -38,7 +38,7 @@ async fn test_core_settings() -> Result<(), Error> {
     assert_eq!(json["is_authenticated"], true);
     assert_eq!(json["is_subscriber"], false);
     assert_eq!(json["settings"]["no_ads"], false);
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -76,6 +76,6 @@ async fn test_subscriber_settings() -> Result<(), Error> {
     assert_eq!(json["is_authenticated"], true);
     assert_eq!(json["is_subscriber"], true);
     assert_eq!(json["settings"]["no_ads"], true);
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/fxa/callback.rs
+++ b/tests/fxa/callback.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 
 use url::Url;
 
-use crate::helpers::app::test_app_with_login;
+use crate::helpers::app::{drop_stubr, test_app_with_login};
 use crate::helpers::db::reset;
-use crate::helpers::wait_for_stubr;
 
 #[actix_rt::test]
 #[stubr::mock(port = 4321)]
@@ -49,8 +48,7 @@ async fn basic() -> Result<(), Error> {
     let res = test::call_service(&app, base.to_request()).await;
     assert!(res.status().is_redirection());
     assert_eq!(res.headers().get("Location").unwrap(), "/");
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -58,7 +56,6 @@ async fn basic() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn next() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await.unwrap();
     let app = test::init_service(app).await;
@@ -98,8 +95,7 @@ async fn next() -> Result<(), Error> {
         res.headers().get("Location").unwrap(),
         "http://localhost:8000/foo"
     );
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -107,7 +103,6 @@ async fn next() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn next_absolute() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await.unwrap();
     let app = test::init_service(app).await;
@@ -144,8 +139,7 @@ async fn next_absolute() -> Result<(), Error> {
     let res = test::call_service(&app, base.to_request()).await;
     assert!(res.status().is_redirection());
     assert_eq!(res.headers().get("Location").unwrap(), "/");
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -153,7 +147,6 @@ async fn next_absolute() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn next_absolute_without_protocol() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await.unwrap();
     let app = test::init_service(app).await;
@@ -190,8 +183,7 @@ async fn next_absolute_without_protocol() -> Result<(), Error> {
     let res = test::call_service(&app, base.to_request()).await;
     assert!(res.status().is_redirection());
     assert_eq!(res.headers().get("Location").unwrap(), "/");
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -199,7 +191,6 @@ async fn next_absolute_without_protocol() -> Result<(), Error> {
 #[stubr::mock(port = 4321)]
 async fn next_absolute_with_path_exploit() -> Result<(), Error> {
     let pool = reset()?;
-    wait_for_stubr().await?;
 
     let app = test_app_with_login(&pool).await.unwrap();
     let app = test::init_service(app).await;
@@ -239,8 +230,7 @@ async fn next_absolute_with_path_exploit() -> Result<(), Error> {
         res.headers().get("Location").unwrap(),
         "http://localhost:8000//foo.com/bar"
     );
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }
 
@@ -294,7 +284,6 @@ async fn no_prompt() -> Result<(), Error> {
         res.headers().get("Location").unwrap(),
         "http://localhost:8000/foo"
     );
-
-    drop(stubr);
+    drop_stubr(stubr).await;
     Ok(())
 }

--- a/tests/helpers/app.rs
+++ b/tests/helpers/app.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use actix_http::body::BoxBody;
 use actix_http::Request;
 use actix_identity::IdentityMiddleware;
@@ -25,6 +27,7 @@ use rumba::fxa::LoginManager;
 use rumba::settings::SETTINGS;
 use slog::{slog_o, Drain};
 use stubr::{Config, Stubr};
+use tokio::time::sleep;
 
 use super::db::reset;
 use super::http_client::TestHttpClient;
@@ -159,4 +162,14 @@ pub async fn init_test(
     let service = test::init_service(app).await;
     let logged_in_client = TestHttpClient::new(service).await;
     Ok((logged_in_client, stubr))
+}
+
+// We drop the stubr instances explicitly and add a small
+// delay to give it time to shutdown. This is necessary to fix
+// flaky tests that fail because leftover stubr instances are still
+// holding on the network port in some cases.
+const STUBR_POST_DROP_SLEEP: std::time::Duration = Duration::from_millis(10);
+pub async fn drop_stubr(stubr: Stubr) {
+    drop(stubr);
+    sleep(STUBR_POST_DROP_SLEEP).await;
 }

--- a/tests/helpers/http_client.rs
+++ b/tests/helpers/http_client.rs
@@ -6,8 +6,6 @@ use actix_web::{test, Error};
 use rumba::settings::SETTINGS;
 use std::collections::HashMap;
 
-use reqwest::{Client, Method, StatusCode};
-
 use serde_json::Value;
 use url::Url;
 
@@ -25,8 +23,6 @@ pub enum PostPayload {
 
 impl<T: Service<Request, Response = RumbaTestResponse, Error = Error>> TestHttpClient<T> {
     pub async fn new(service: T) -> Self {
-        let _stubr_ok = check_stubr_initialized().await;
-
         let login_req = test::TestRequest::get()
             .uri("/users/fxa/login/authenticate/")
             .to_request();
@@ -154,14 +150,4 @@ impl<T: Service<Request, Response = RumbaTestResponse, Error = Error>> TestHttpC
         }
         base
     }
-}
-
-pub async fn check_stubr_initialized() -> Result<(), ()> {
-    //Hardcoded for now. We will 'always' spin stubr at localhost:4321.
-    let res = Client::new()
-        .request(Method::GET, "http://localhost:4321/healthz")
-        .send()
-        .await;
-    assert_eq!(res.unwrap().status(), StatusCode::OK);
-    Ok(())
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,13 +1,7 @@
-use std::time::Duration;
-
 use actix_http::body::{BoxBody, EitherBody, MessageBody};
-use actix_rt::{
-    net::TcpStream,
-    time::{sleep, timeout},
-};
+
 use actix_web::dev::ServiceResponse;
 use actix_web::test;
-use anyhow::{anyhow, Error};
 use serde_json::Value;
 
 pub mod api_assertions;
@@ -19,17 +13,4 @@ pub type RumbaTestResponse = ServiceResponse<EitherBody<BoxBody>>;
 
 pub async fn read_json<B: MessageBody + Unpin>(res: ServiceResponse<B>) -> Value {
     serde_json::from_slice(test::read_body(res).await.as_ref()).unwrap()
-}
-
-pub async fn wait_for_stubr() -> Result<(), Error> {
-    timeout(Duration::from_millis(10_000), async {
-        while let Err(_e) = TcpStream::connect(("127.0.0.1", 4321)).await {
-            sleep(Duration::from_millis(100)).await;
-        }
-        Ok::<(), Error>(())
-    })
-    .await
-    .map_err(|_| anyhow!("strubr not ready after 10,000ms"))??;
-
-    Ok(())
 }


### PR DESCRIPTION
* Make sure we drop any `stubr` instance deliberately, both with the attribute macro and with manual setup.
* Drop `stubr` using our own async helper function `drop_stubr(stubr: Stubr)`that drops it and adds 10ms of delay.
* Remove all older check/wait/sleep functions around `stubr`.
* Make sure we only use a single instance of `stubr` inside a test by splitting tests up.

I ran the tests in a loop on my local machine, this version did not fail after around 130 invocations which is where I stopped it.

Shell script to run tests it in a loop:
```sh
LOGFILE=testlog.log
export RUST_LOG=rumba:info
export MDN_SETTINGS=.settings.test.toml
echo "$(date -Iseconds) START" >$LOGFILE
while true; do
	cargo test --all -- --test-threads=1 --nocapture; 
	if [ $? -ne 0 ]; then 
		echo "$(date -Iseconds) ===== The test failed. ======" | tee -a $LOGFILE; 
		break; 
	else 
		echo "$(date -Iseconds) OK" >>$LOGFILE
		sleep 0.1; 
		clear; 
	fi; 
done
```