### PR TITLE
fix(ai): history fix

### DIFF
--- a/src/api/ai_help.rs
+++ b/src/api/ai_help.rs
@@ -26,7 +26,7 @@ use crate::{
             delete_help_history, get_count, help_history, help_history_get_message,
             list_help_history, update_help_history_label, AI_HELP_LIMIT,
         },
-        model::{AIHelpHistoryMessage, AIHelpHistoryMessageInsert, Settings, UserQuery},
+        model::{AIHelpHistoryMessage, AIHelpHistoryMessageInsert, Settings},
         settings::get_settings,
         SupaPool,
     },
@@ -195,7 +195,7 @@ fn record_question(
     pool: &Data<Pool>,
     message: &ChatCompletionRequestMessage,
     history_enabled: bool,
-    user: &UserQuery,
+    user_id: i64,
     help_ids: HelpIds,
 ) -> Result<Option<NaiveDateTime>, ApiError> {
     if !history_enabled {
@@ -209,7 +209,7 @@ fn record_question(
     } = help_ids;
 
     let insert = AIHelpHistoryMessageInsert {
-        user_id: user.id,
+        user_id,
         chat_id,
         message_id,
         parent_id,
@@ -231,7 +231,7 @@ fn record_sources(
     pool: &Data<Pool>,
     sources: &Vec<RefDoc>,
     history_enabled: bool,
-    user: &UserQuery,
+    user_id: i64,
     help_ids: HelpIds,
 ) -> Result<Option<NaiveDateTime>, ApiError> {
     if !history_enabled {
@@ -245,7 +245,7 @@ fn record_sources(
     } = help_ids;
 
     let insert = AIHelpHistoryMessageInsert {
-        user_id: user.id,
+        user_id,
         chat_id,
         message_id,
         parent_id,
@@ -392,7 +392,7 @@ pub async fn ai_help(
                 &diesel_pool,
                 question,
                 history_enabled(&settings),
-                &user,
+                user.id,
                 help_ids,
             )?;
         }
@@ -404,7 +404,7 @@ pub async fn ai_help(
                     &diesel_pool,
                     &sources,
                     history_enabled(&settings),
-                    &user,
+                    user.id,
                     help_ids,
                 )? {
                     Some(x) => Utc.from_utc_datetime(&x),

--- a/src/api/ai_help.rs
+++ b/src/api/ai_help.rs
@@ -22,10 +22,9 @@ use crate::{
     db::{
         self,
         ai_help::{
-            add_help_history, add_help_history_message, create_or_increment_total,
-            delete_full_help_history, delete_help_history, get_count, help_history,
-            help_history_get_message, list_help_history, update_help_history,
-            update_help_history_label, AI_HELP_LIMIT,
+            add_help_history_message, create_or_increment_total, delete_full_help_history,
+            delete_help_history, get_count, help_history, help_history_get_message,
+            list_help_history, update_help_history_label, AI_HELP_LIMIT,
         },
         model::{AIHelpHistoryMessage, AIHelpHistoryMessageInsert, Settings, UserQuery},
         settings::get_settings,
@@ -208,23 +207,6 @@ fn record_question(
         message_id,
         parent_id,
     } = help_ids;
-
-    // If a `parent_id` is present, we execute an update on the help history
-    // record because one of these are true:
-    // * We created a history record at the beginning of the conversation.
-    // * History was switched off, we did not create a record and the update
-    //   will simply not match/change any record.
-    //
-    // With no `parent_id`, we create a new record because at this point, history
-    // _is_ enabled and we are at the start of a new conversation.
-    let res = if parent_id.is_some() {
-        update_help_history(&mut conn, user.id, chat_id)
-    } else {
-        add_help_history(&mut conn, user.id, chat_id)
-    };
-    if let Err(err) = res {
-        error!("AI Help log: {err}");
-    }
 
     let insert = AIHelpHistoryMessageInsert {
         user_id: user.id,

--- a/src/api/ai_help.rs
+++ b/src/api/ai_help.rs
@@ -222,7 +222,6 @@ fn record_question(
     } else {
         add_help_history(&mut conn, user.id, chat_id)
     };
-
     if let Err(err) = res {
         error!("AI Help log: {err}");
     }
@@ -257,18 +256,11 @@ fn record_sources(
         return Ok(None);
     }
     let mut conn = pool.get()?;
-
     let HelpIds {
         chat_id,
         message_id,
         parent_id,
     } = help_ids;
-    if let Some(parent_id) = parent_id {
-        let parent_message = help_history_get_message(&mut conn, user, &parent_id)?;
-        if parent_message.is_none() {
-            return Ok(None);
-        }
-    }
 
     let insert = AIHelpHistoryMessageInsert {
         user_id: user.id,

--- a/src/db/ai_help.rs
+++ b/src/db/ai_help.rs
@@ -287,10 +287,7 @@ pub fn update_help_history_label(
                 .eq(user.id)
                 .and(ai_help_history::chat_id.eq(chat_id)),
         )
-        .set((
-            ai_help_history::label.eq(label),
-            ai_help_history::updated_at.eq(diesel::dsl::now),
-        ))
+        .set(ai_help_history::label.eq(label))
         .execute(conn)?;
     Ok(())
 }

--- a/src/db/ai_help.rs
+++ b/src/db/ai_help.rs
@@ -140,21 +140,6 @@ pub fn add_help_history_message(
     conn: &mut PgConnection,
     mut message: AIHelpHistoryMessageInsert,
 ) -> Result<NaiveDateTime, DbError> {
-    // Check if the parent message exists in the database first.
-    // We could end up with a non-existing parent message if the
-    // user enables history after the conversation has already
-    // started. Do not try to store the message in that case.
-    if let Some(parent_id) = message.parent_id {
-        let parent_message_count = ai_help_history_messages::table
-            .filter(ai_help_history_messages::message_id.eq(&parent_id))
-            .count()
-            .get_result::<i64>(conn)?;
-        if parent_message_count == 0 {
-            return Ok(Utc::now().naive_utc());
-        }
-    }
-
-    // Ok, we are good on the parent message.
     let updated_at = update(ai_help_history::table)
         .filter(
             ai_help_history::user_id

--- a/tests/api/ai_help_history.rs
+++ b/tests/api/ai_help_history.rs
@@ -5,12 +5,9 @@ use actix_web::test;
 use anyhow::Error;
 use async_openai::types::ChatCompletionRequestMessage;
 use async_openai::types::Role::{Assistant, User};
-use diesel::prelude::*;
-use diesel::ExpressionMethods;
 use rumba::ai::help::RefDoc;
 use rumba::db::ai_help::{add_help_history, add_help_history_message};
 use rumba::db::model::{AIHelpHistoryMessageInsert, SettingsInsert};
-use rumba::db::schema::ai_help_history_messages;
 use rumba::db::settings::create_or_update_settings;
 use serde_json::Value::Null;
 use uuid::Uuid;
@@ -94,48 +91,6 @@ async fn test_history() -> Result<(), Error> {
             test::read_body(history).await.as_ref()
         ))
     );
-    drop_stubr(stubr).await;
-    Ok(())
-}
-
-#[actix_rt::test]
-#[stubr::mock(port = 4321)]
-async fn test_history_message_without_parent() -> Result<(), Error> {
-    let pool = reset()?;
-    let app = test_app_with_login(&pool).await.unwrap();
-    let service = test::init_service(app).await;
-    let mut _logged_in_client = TestHttpClient::new(service).await;
-
-    let mut conn = pool.get()?;
-    // Make sure that history is enabled
-    create_or_update_settings(
-        &mut conn,
-        SettingsInsert {
-            user_id: 1,
-            ai_help_history: Some(true),
-            ..Default::default()
-        },
-    )?;
-
-    // create a message with a non-existing parent
-    let message = AIHelpHistoryMessageInsert {
-        user_id: 1,
-        chat_id: CHAT_ID,
-        message_id: MESSAGE_ID,
-        parent_id: Some(Uuid::from_u128(2)),
-        created_at: None,
-        sources: None,
-        request: None,
-        response: None,
-    };
-    let res = add_help_history_message(&mut conn, message);
-    // We return OK, but the message should not be recorded.
-    assert!(res.is_ok());
-    let message_count = ai_help_history_messages::table
-        .filter(ai_help_history_messages::user_id.eq(1))
-        .count()
-        .get_result::<i64>(&mut conn)?;
-    assert_eq!(message_count, 0);
     drop_stubr(stubr).await;
     Ok(())
 }


### PR DESCRIPTION
Prevent persisting to ai help history if a message's parent message can not be found in the database. 

(MP-870)

This resolves the special case where a user turns on history mid-conversation (in a different tab). Conversations that were started while history was turned off are not stored now and do not result in an error.
