### PR TITLE
fix(updates): make browser_releases.release_date nullable

### DIFF
--- a/migrations/2024-02-21-180000_browsers_without_release_date/down.sql
+++ b/migrations/2024-02-21-180000_browsers_without_release_date/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE browser_releases ALTER COLUMN release_date SET NOT NULL;

--- a/migrations/2024-02-21-180000_browsers_without_release_date/down.sql
+++ b/migrations/2024-02-21-180000_browsers_without_release_date/down.sql
@@ -1,1 +1,2 @@
+DELETE FROM browser_releases WHERE release_date IS NULL;
 ALTER TABLE browser_releases ALTER COLUMN release_date SET NOT NULL;

--- a/migrations/2024-02-21-180000_browsers_without_release_date/up.sql
+++ b/migrations/2024-02-21-180000_browsers_without_release_date/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE browser_releases ALTER COLUMN release_date DROP NOT NULL;

--- a/src/api/v2/updates.rs
+++ b/src/api/v2/updates.rs
@@ -92,7 +92,7 @@ pub struct BcdUpdate {
     #[serde(flatten)]
     pub browser: Option<BrowserInfo>,
     pub events: BcdUpdateEvent,
-    pub release_date: NaiveDate,
+    pub release_date: Option<NaiveDate>,
 }
 
 fn query_contains_restricted_filters(query: &BcdUpdatesQueryParams) -> bool {
@@ -154,7 +154,7 @@ pub async fn get_updates(
                     release_notes: "".to_string(),
                     version: key.5,
                 }),
-                release_date: key.4,
+                release_date: Some(key.4),
                 events: BcdUpdateEvent { added, removed },
             }
         })

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -146,7 +146,7 @@ diesel::table! {
         engine -> Text,
         engine_version -> Text,
         release_id -> Text,
-        release_date -> Date,
+        release_date -> Nullable<Date>,
         release_notes -> Nullable<Text>,
         status -> Nullable<Text>,
     }

--- a/src/db/v2/synchronize_bcd_updates_db.rs
+++ b/src/db/v2/synchronize_bcd_updates_db.rs
@@ -93,25 +93,19 @@ async fn synchronize_browers_and_releases(
         for (release, value) in v["releases"].as_object().unwrap() {
             match value["engine"].as_str() {
                 Some(_) => (),
-                None => debug!("No engine for {:?}", value),
-            }
-            match value["release_date"].as_str() {
-                Some(_) => (),
-                None => debug!("No release_date for {:?}", value),
+                None => println!("No engine for {:?}", value),
             }
             let _release_date: Option<NaiveDate> = value["release_date"]
                 .as_str()
                 .map_or_else(|| None, |v| Some(NaiveDate::from_str(v).unwrap()));
-            if _release_date.is_none() {
-                return;
-            }
+
             releases.push((
                 browser_releases::browser.eq(k.as_str()),
                 browser_releases::engine.eq(value["engine"].as_str().unwrap_or("Unknown")),
                 browser_releases::engine_version
                     .eq(value["engine_version"].as_str().unwrap_or("Unknown")),
                 browser_releases::release_id.eq(release),
-                browser_releases::release_date.eq(_release_date.unwrap()),
+                browser_releases::release_date.eq(_release_date),
                 browser_releases::release_notes.eq(value["release_notes"].as_str()),
                 browser_releases::status.eq(value["status"].as_str()),
             ));


### PR DESCRIPTION
The browser-compat-data schema for browser data does not require the release_date, and unfortunately some browser releases are currently missing a release_date.

(MP-751)

See: https://github.com/mdn/browser-compat-data/issues/22274