### PR TITLE
feat(ai-help): bump GPT-3.5 Turbo model

### DIFF
--- a/src/ai/constants.rs
+++ b/src/ai/constants.rs
@@ -25,7 +25,7 @@ fn join_with_tags(related_docs: Vec<RelatedDoc>) -> String {
 
 pub const AI_HELP_GPT3_5_FULL_DOC_NEW_PROMPT: AIHelpConfig = AIHelpConfig {
     name: "20230901-full_doc-new_prompt",
-    model: "gpt-3.5-turbo-1106",
+    model: "gpt-3.5-turbo-0125",
     full_doc: true,
     system_prompt: include_str!("prompts/new_prompt/system.md"),
     user_prompt: None,


### PR DESCRIPTION
Switch to the new GPT-3.5 Turbo model, which produces mostly equivalent and more slightly better than slightly worse answers according to our tests.

(MP-856)