### PR TITLE
feat(playground): return ownership info

### DIFF
--- a/src/db/play.rs
+++ b/src/db/play.rs
@@ -1,20 +1,38 @@
 use crate::db::model::PlaygroundInsert;
-use crate::db::schema;
+use crate::db::schema::playground;
 
-use diesel::{insert_into, PgConnection};
+use diesel::dsl::exists;
+use diesel::{insert_into, select, PgConnection};
 use diesel::{prelude::*, update};
+
+use super::model::UserQuery;
 
 pub fn create_playground(
     conn: &mut PgConnection,
     playground: PlaygroundInsert,
 ) -> QueryResult<usize> {
-    insert_into(schema::playground::table)
+    insert_into(playground::table)
         .values(&playground)
         .execute(conn)
 }
 
+pub fn is_playground_created_by_user(
+    conn: &mut PgConnection,
+    gist_id: &str,
+    user: UserQuery,
+) -> QueryResult<bool> {
+    select(exists(
+        playground::table.filter(
+            playground::gist
+                .eq(gist_id)
+                .and(playground::user_id.eq(user.id)),
+        ),
+    ))
+    .get_result(conn)
+}
+
 pub fn flag_playground(conn: &mut PgConnection, gist_id: &str) -> QueryResult<usize> {
-    update(schema::playground::table.filter(schema::playground::gist.eq(gist_id)))
-        .set(schema::playground::flagged.eq(true))
+    update(playground::table.filter(playground::gist.eq(gist_id)))
+        .set(playground::flagged.eq(true))
         .execute(conn)
 }


### PR DESCRIPTION
Allows us to hide the "Seeing something inappropriate?" link for playgrounds that the current user owns, to avoid false-negative reports.