### PR TITLE
fix(auto-merge): exclude pre-1.0.0 major changes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,10 +9,17 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+
     steps:
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
-          command: "squash and merge"
-          approve: true
-          target: minor
+
+      - name: Squash and merge
+      
+        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' && !startsWith(steps.dependabot-metadata.outputs.previous-version, '0.') || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' && !startsWith(steps.dependabot-metadata.outputs.previous-version, '0.0.') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+        run: gh pr comment ${{ github.event.pull_request.html_url }} --body "@dependabot squash and merge"


### PR DESCRIPTION
Based on https://github.com/mdn/yari/blob/db188c5907799df1a580a43c89c35243bbc4cf2c/.github/workflows/auto-merge.yml, with additional conditions for Cargo's special handling of pre-1.0.0 versions:

"(...) Cargo uses the convention that only changes in the left-most non-zero component are considered incompatible."

See: https://doc.rust-lang.org/cargo/reference/semver.html

(MP-1051)