### PR TITLE
ci(github): configure dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     commit-message:
       prefix: "build(deps): "
       prefix-development: "build(dev-deps): "
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps): "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "build(deps): "


### PR DESCRIPTION
There are many out-of-dated GitHub Actions, configure dependabot for GitHub Actions to automatically upgrade them.

See [workflow runs](https://github.com/mdn/rumba/actions/runs/10783652269).
