### PR TITLE
fix(docker): ignore GCP token file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,6 @@ secret-*.yaml
 target/
 !target/release/rumba
 **/.terraform/*
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
reference bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1959182