### PR TITLE
fix(prod-build): remove ref_protected requirement, add tag input

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -38,6 +38,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Validate tag format
+        if: inputs.tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Invalid tag: $TAG does not match format vX.Y.Z (e.g., v1.2.3)"
+            exit 1
+          fi
+          echo "✅ Valid tag: $TAG"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository_owner == 'mdn' && github.ref_type == 'tag' && github.ref_protected
+    if: github.repository_owner == 'mdn'
     uses: ./.github/workflows/_build.yml
     secrets: inherit
     with:

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -6,6 +6,10 @@ on:
       - "v*"
 
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v1.13.0)"
+        required: true
 
 permissions:
   # Read/write GHA cache.
@@ -22,5 +26,5 @@ jobs:
     secrets: inherit
     with:
       environment: prod
-      ref: ${{ github.ref }}
-      tag: ${{ github.ref_name }}
+      ref: ${{ inputs.tag || github.ref }}
+      tag: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
It appears `ref_protected` is only true if tag creation
is protected, which prevents github-actions from tagging.