### PR TITLE
chore(docker): ignore `.env` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .settings.test.toml
 .settings*.json
 secret-*.yaml
+.env
 .git/
 .vscode/
 .idea/


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Ignore the `.env` file.

Note: Even if rumba doesn't use this file, it's theoretically possible for someone to accidentally create it locally.

### Motivation

Apply best practices.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/872.