### PR TITLE
chore(play): split playground PAT into gist and flags tokens

### DIFF
--- a/.settings.dev.toml
+++ b/.settings.dev.toml
@@ -44,8 +44,8 @@ api_key = ""
 basket_url = ""
 
 [playground]
-gist_token = ""
-flags_token = ""
+github_gist_token = ""
+github_flags_token = ""
 crypt_key = ""
 flag_repo = "flags"
 

--- a/.settings.dev.toml
+++ b/.settings.dev.toml
@@ -44,7 +44,8 @@ api_key = ""
 basket_url = ""
 
 [playground]
-github_token = ""
+gist_token = ""
+flags_token = ""
 crypt_key = ""
 flag_repo = "flags"
 

--- a/.settings.local.toml
+++ b/.settings.local.toml
@@ -44,8 +44,8 @@ api_key = ""
 basket_url = ""
 
 [playground]
-gist_token = ""
-flags_token = ""
+github_gist_token = ""
+github_flags_token = ""
 crypt_key = ""
 flag_repo = "flags"
 

--- a/.settings.local.toml
+++ b/.settings.local.toml
@@ -44,7 +44,8 @@ api_key = ""
 basket_url = ""
 
 [playground]
-github_token = ""
+gist_token = ""
+flags_token = ""
 crypt_key = ""
 flag_repo = "flags"
 

--- a/.settings.test.toml
+++ b/.settings.test.toml
@@ -44,8 +44,8 @@ api_key = "foobar"
 basket_url = "http://localhost:4321"
 
 [playground]
-gist_token = "foobar"
-flags_token = "foobar"
+github_gist_token = "foobar"
+github_flags_token = "foobar"
 crypt_key = "IXAe2h1MekK4LKysmMvxomja69PT6c20A3nmcDHQ2eQ="
 flag_repo = "flags"
 

--- a/.settings.test.toml
+++ b/.settings.test.toml
@@ -44,7 +44,8 @@ api_key = "foobar"
 basket_url = "http://localhost:4321"
 
 [playground]
-github_token = "foobar"
+gist_token = "foobar"
+flags_token = "foobar"
 crypt_key = "IXAe2h1MekK4LKysmMvxomja69PT6c20A3nmcDHQ2eQ="
 flag_repo = "flags"
 

--- a/src/api/play.rs
+++ b/src/api/play.rs
@@ -25,6 +25,9 @@ use crate::{
 const FILENAME: &str = "playground.json";
 const DESCRIPTION: &str = "Code shared from the MDN Playground";
 
+pub struct GistClient(pub Option<Octocrab>);
+pub struct FlagsClient(pub Option<Octocrab>);
+
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub struct PlayCode {
     html: Option<String>,
@@ -166,9 +169,9 @@ pub async fn save(
     save: web::Json<PlayCode>,
     id: Option<Identity>,
     pool: web::Data<Pool>,
-    github_client: web::Data<Option<Octocrab>>,
+    gist_client: web::Data<GistClient>,
 ) -> Result<HttpResponse, ApiError> {
-    if let Some(client) = &**github_client {
+    if let Some(client) = &gist_client.0 {
         if let Some(user_id) = id {
             let gist =
                 create_gist(client, serde_json::to_string_pretty(&save.into_inner())?).await?;
@@ -196,9 +199,9 @@ pub async fn save(
 
 pub async fn load(
     gist_id: web::Path<String>,
-    github_client: web::Data<Option<Octocrab>>,
+    gist_client: web::Data<GistClient>,
 ) -> Result<HttpResponse, ApiError> {
-    if let Some(client) = &**github_client {
+    if let Some(client) = &gist_client.0 {
         let id = decrypt(&gist_id.into_inner())?;
         let gist = load_gist(client, &id).await?;
         Ok(HttpResponse::Ok().json(gist.code))
@@ -210,9 +213,9 @@ pub async fn load(
 pub async fn flag(
     flag: web::Json<PlayFlagRequest>,
     pool: web::Data<Pool>,
-    github_client: web::Data<Option<Octocrab>>,
+    flags_client: web::Data<FlagsClient>,
 ) -> Result<HttpResponse, ApiError> {
-    if let Some(client) = &**github_client {
+    if let Some(client) = &flags_client.0 {
         let PlayFlagRequest { id, reason } = flag.into_inner();
         let gist_id = decrypt(&id)?;
         let mut conn = pool.get()?;

--- a/src/api/play.rs
+++ b/src/api/play.rs
@@ -25,8 +25,8 @@ use crate::{
 const FILENAME: &str = "playground.json";
 const DESCRIPTION: &str = "Code shared from the MDN Playground";
 
-pub struct GistClient(pub Option<Octocrab>);
-pub struct FlagsClient(pub Option<Octocrab>);
+pub struct GithubGistClient(pub Option<Octocrab>);
+pub struct GithubFlagsClient(pub Option<Octocrab>);
 
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub struct PlayCode {
@@ -169,9 +169,9 @@ pub async fn save(
     save: web::Json<PlayCode>,
     id: Option<Identity>,
     pool: web::Data<Pool>,
-    gist_client: web::Data<GistClient>,
+    github_gist_client: web::Data<GithubGistClient>,
 ) -> Result<HttpResponse, ApiError> {
-    if let Some(client) = &gist_client.0 {
+    if let Some(client) = &github_gist_client.0 {
         if let Some(user_id) = id {
             let gist =
                 create_gist(client, serde_json::to_string_pretty(&save.into_inner())?).await?;
@@ -199,9 +199,9 @@ pub async fn save(
 
 pub async fn load(
     gist_id: web::Path<String>,
-    gist_client: web::Data<GistClient>,
+    github_gist_client: web::Data<GithubGistClient>,
 ) -> Result<HttpResponse, ApiError> {
-    if let Some(client) = &gist_client.0 {
+    if let Some(client) = &github_gist_client.0 {
         let id = decrypt(&gist_id.into_inner())?;
         let gist = load_gist(client, &id).await?;
         Ok(HttpResponse::Ok().json(gist.code))
@@ -213,9 +213,9 @@ pub async fn load(
 pub async fn flag(
     flag: web::Json<PlayFlagRequest>,
     pool: web::Data<Pool>,
-    flags_client: web::Data<FlagsClient>,
+    github_flags_client: web::Data<GithubFlagsClient>,
 ) -> Result<HttpResponse, ApiError> {
-    if let Some(client) = &flags_client.0 {
+    if let Some(client) = &github_flags_client.0 {
         let PlayFlagRequest { id, reason } = flag.into_inner();
         let gist_id = decrypt(&id)?;
         let mut conn = pool.get()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use reqwest::Client as HttpClient;
 use rumba::{
     add_services,
     api::error::{error_handler, ERROR_ID_HEADER_NAME_STR},
-    api::play::{FlagsClient, GistClient},
+    api::play::{GithubFlagsClient, GithubGistClient},
     db,
     fxa::LoginManager,
     logging::{self, init_logging},
@@ -100,18 +100,22 @@ async fn main() -> anyhow::Result<()> {
             async_openai::Client::with_config(OpenAIConfig::new().with_api_key(&c.api_key))
         }));
 
-    let gist_client = Data::new(GistClient(SETTINGS.playground.as_ref().and_then(|p| {
-        OctocrabBuilder::new()
-            .personal_token(p.gist_token.clone())
-            .build()
-            .ok()
-    })));
-    let flags_client = Data::new(FlagsClient(SETTINGS.playground.as_ref().and_then(|p| {
-        OctocrabBuilder::new()
-            .personal_token(p.flags_token.clone())
-            .build()
-            .ok()
-    })));
+    let github_gist_client = Data::new(GithubGistClient(SETTINGS.playground.as_ref().and_then(
+        |p| {
+            OctocrabBuilder::new()
+                .personal_token(p.github_gist_token.clone())
+                .build()
+                .ok()
+        },
+    )));
+    let github_flags_client = Data::new(GithubFlagsClient(SETTINGS.playground.as_ref().and_then(
+        |p| {
+            OctocrabBuilder::new()
+                .personal_token(p.github_flags_token.clone())
+                .build()
+                .ok()
+        },
+    )));
 
     HttpServer::new(move || {
         let app = App::new()
@@ -131,8 +135,8 @@ async fn main() -> anyhow::Result<()> {
             )
             .wrap(Logger::new(LOG_FMT).exclude("/healthz"))
             .app_data(Data::clone(&openai_client))
-            .app_data(Data::clone(&gist_client))
-            .app_data(Data::clone(&flags_client))
+            .app_data(Data::clone(&github_gist_client))
+            .app_data(Data::clone(&github_flags_client))
             .app_data(Data::clone(&basket_client))
             .app_data(Data::clone(&metrics))
             .app_data(Data::clone(&pool))

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use reqwest::Client as HttpClient;
 use rumba::{
     add_services,
     api::error::{error_handler, ERROR_ID_HEADER_NAME_STR},
+    api::play::{FlagsClient, GistClient},
     db,
     fxa::LoginManager,
     logging::{self, init_logging},
@@ -99,12 +100,18 @@ async fn main() -> anyhow::Result<()> {
             async_openai::Client::with_config(OpenAIConfig::new().with_api_key(&c.api_key))
         }));
 
-    let github_client = Data::new(SETTINGS.playground.as_ref().and_then(|p| {
+    let gist_client = Data::new(GistClient(SETTINGS.playground.as_ref().and_then(|p| {
         OctocrabBuilder::new()
-            .personal_token(p.github_token.clone())
+            .personal_token(p.gist_token.clone())
             .build()
             .ok()
-    }));
+    })));
+    let flags_client = Data::new(FlagsClient(SETTINGS.playground.as_ref().and_then(|p| {
+        OctocrabBuilder::new()
+            .personal_token(p.flags_token.clone())
+            .build()
+            .ok()
+    })));
 
     HttpServer::new(move || {
         let app = App::new()
@@ -124,7 +131,8 @@ async fn main() -> anyhow::Result<()> {
             )
             .wrap(Logger::new(LOG_FMT).exclude("/healthz"))
             .app_data(Data::clone(&openai_client))
-            .app_data(Data::clone(&github_client))
+            .app_data(Data::clone(&gist_client))
+            .app_data(Data::clone(&flags_client))
             .app_data(Data::clone(&basket_client))
             .app_data(Data::clone(&metrics))
             .app_data(Data::clone(&pool))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -89,8 +89,8 @@ pub struct AI {
 #[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Playground {
-    pub gist_token: String,
-    pub flags_token: String,
+    pub github_gist_token: String,
+    pub github_flags_token: String,
     #[serde_as(as = "Base64")]
     pub crypt_key: [u8; 32],
     pub flag_repo: String,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -89,7 +89,8 @@ pub struct AI {
 #[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Playground {
-    pub github_token: String,
+    pub gist_token: String,
+    pub flags_token: String,
     #[serde_as(as = "Base64")]
     pub crypt_key: [u8; 32],
     pub flag_repo: String,

--- a/tests/helpers/app.rs
+++ b/tests/helpers/app.rs
@@ -21,6 +21,7 @@ use octocrab::OctocrabBuilder;
 use reqwest::Client;
 use rumba::add_services;
 use rumba::api::error::error_handler;
+use rumba::api::play::{FlagsClient, GistClient};
 use rumba::db::{Pool, SupaPool};
 use rumba::fxa::LoginManager;
 use rumba::settings::SETTINGS;
@@ -67,12 +68,18 @@ pub async fn test_app_with_login(
     let arbiter = Arbiter::new();
     let arbiter_handle = Data::new(arbiter.handle());
     let session_cookie_key = Key::derive_from(&SETTINGS.auth.cookie_key);
-    let github_client = Data::new(Some(
+    let gist_client = Data::new(GistClient(Some(
         OctocrabBuilder::new()
             .base_uri("http://localhost:4321")
             .unwrap()
             .build()?,
-    ));
+    )));
+    let flags_client = Data::new(FlagsClient(Some(
+        OctocrabBuilder::new()
+            .base_uri("http://localhost:4321")
+            .unwrap()
+            .build()?,
+    )));
     let basket_client = Data::new(
         SETTINGS
             .basket
@@ -95,7 +102,8 @@ pub async fn test_app_with_login(
         .app_data(Data::clone(&arbiter_handle))
         .app_data(Data::clone(&openai_client))
         .app_data(Data::clone(&supabase_pool))
-        .app_data(Data::clone(&github_client))
+        .app_data(Data::clone(&gist_client))
+        .app_data(Data::clone(&flags_client))
         .app_data(Data::clone(&pool))
         .app_data(Data::clone(&client))
         .app_data(Data::clone(&basket_client))

--- a/tests/helpers/app.rs
+++ b/tests/helpers/app.rs
@@ -21,7 +21,7 @@ use octocrab::OctocrabBuilder;
 use reqwest::Client;
 use rumba::add_services;
 use rumba::api::error::error_handler;
-use rumba::api::play::{FlagsClient, GistClient};
+use rumba::api::play::{GithubFlagsClient, GithubGistClient};
 use rumba::db::{Pool, SupaPool};
 use rumba::fxa::LoginManager;
 use rumba::settings::SETTINGS;
@@ -68,13 +68,13 @@ pub async fn test_app_with_login(
     let arbiter = Arbiter::new();
     let arbiter_handle = Data::new(arbiter.handle());
     let session_cookie_key = Key::derive_from(&SETTINGS.auth.cookie_key);
-    let gist_client = Data::new(GistClient(Some(
+    let github_gist_client = Data::new(GithubGistClient(Some(
         OctocrabBuilder::new()
             .base_uri("http://localhost:4321")
             .unwrap()
             .build()?,
     )));
-    let flags_client = Data::new(FlagsClient(Some(
+    let github_flags_client = Data::new(GithubFlagsClient(Some(
         OctocrabBuilder::new()
             .base_uri("http://localhost:4321")
             .unwrap()
@@ -102,8 +102,8 @@ pub async fn test_app_with_login(
         .app_data(Data::clone(&arbiter_handle))
         .app_data(Data::clone(&openai_client))
         .app_data(Data::clone(&supabase_pool))
-        .app_data(Data::clone(&gist_client))
-        .app_data(Data::clone(&flags_client))
+        .app_data(Data::clone(&github_gist_client))
+        .app_data(Data::clone(&github_flags_client))
         .app_data(Data::clone(&pool))
         .app_data(Data::clone(&client))
         .app_data(Data::clone(&basket_client))


### PR DESCRIPTION
### Description

Split the playground feature's single `playground.github_token` into two scoped tokens:

- `playground.github_gist_token` — backs a `GithubGistClient` used by `create_gist` / `load_gist`.
- `playground.github_flags_token` — backs a `GithubFlagsClient` used by `create_flag_issue` on `mdn/playground-flags`.

Each token now drives its own `Octocrab` instance, registered as a distinct `app_data` type so handlers extract the correct client.

### Motivation

Reduce blast radius. Today one classic PAT owned by `mdn-bot` does both jobs. After this change:

- The gist token can stay a classic PAT with only the `gist` scope (the Gist API does not accept fine-grained PATs).
- The flags token can be a fine-grained PAT scoped to the single repo `mdn/playground-flags` with `Issues: Read and write`.

If either token leaks, the other surface is unaffected.

### Additional details

- Settings field renamed `github_token` → `github_gist_token`, plus new `github_flags_token`. Env override names become `MDN__PLAYGROUND__GITHUB_GIST_TOKEN` and `MDN__PLAYGROUND__GITHUB_FLAGS_TOKEN`; `MDN__PLAYGROUND__GITHUB_TOKEN` is retired.
- Deployment-side secret provisioning lives outside this repo and needs a coordinated rename: introduce `MDN_PLAYGROUND_GITHUB_GIST_PAT` and `MDN_PLAYGROUND_GITHUB_FLAGS_PAT`, retire the old combined PAT.
- `.settings.dev.toml`, `.settings.test.toml`, `.settings.local.toml` updated to the new field names.
- Test harness `tests/helpers/app.rs` now builds both clients (both pointed at the stubr base URL).

### Related issues and pull requests