### PR TITLE
ci(workflows): add needs-triage workflow

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,16 @@
+name: needs-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    if: github.repository_owner == 'mdn'
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main


### PR DESCRIPTION
### Description

Syncs `.github/workflows/needs-triage.yml` from [`mdn/fred@82f3524`](https://github.com/mdn/fred/blob/82f352446e9fc3e619d1124f0b57068e34b030d5/.github/workflows/needs-triage.yml).

### Motivation

Keeps this file consistent with the canonical version in `mdn/fred`.

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/1564.
