### PR TITLE
chore(play): verify gist owner

### DIFF
--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -61,6 +61,8 @@ pub enum PlaygroundError {
     UtfDecodeError(#[from] FromUtf8Error),
     #[error("Playground error: no settings")]
     SettingsError,
+    #[error("Gist not owned by the playground bot user")]
+    NotGistOwner,
 }
 
 impl ResponseError for PlaygroundError {
@@ -70,6 +72,7 @@ impl ResponseError for PlaygroundError {
             | PlaygroundError::DecodeError(_)
             | PlaygroundError::NoNonceError
             | PlaygroundError::UtfDecodeError(_) => StatusCode::BAD_REQUEST,
+            PlaygroundError::NotGistOwner => StatusCode::FORBIDDEN,
             PlaygroundError::OctocrabError(_) | PlaygroundError::SettingsError => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }

--- a/src/api/play.rs
+++ b/src/api/play.rs
@@ -48,6 +48,18 @@ pub struct Gist {
 }
 
 #[derive(Deserialize)]
+struct GistOwner {
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct GistWithOwner {
+    owner: Option<GistOwner>,
+    #[serde(flatten)]
+    gist: octocrab::models::gists::Gist,
+}
+
+#[derive(Deserialize)]
 pub struct PlayFlagRequest {
     id: String,
     reason: Option<String>,
@@ -61,7 +73,7 @@ static CIPHER: Lazy<Option<Aes256Gcm>> = Lazy::new(|| {
         .map(|playground| Aes256Gcm::new(GenericArray::from_slice(&playground.crypt_key)))
 });
 
-fn encrypt(gist_id: &str) -> Result<String, PlaygroundError> {
+pub fn encrypt(gist_id: &str) -> Result<String, PlaygroundError> {
     if let Some(cipher) = &*CIPHER {
         let mut nonce = vec![0; NONCE_LEN];
         OsRng.fill_bytes(&mut nonce);
@@ -157,12 +169,16 @@ pub async fn create_flag_issue(
 }
 
 pub async fn load_gist(client: &Octocrab, id: &str) -> Result<Gist, PlaygroundError> {
-    client
-        .gists()
-        .get(id)
-        .await
-        .map(Into::into)
-        .map_err(Into::into)
+    let expected_owner = SETTINGS
+        .playground
+        .as_ref()
+        .map(|p| p.github_gist_owner.as_str())
+        .ok_or(PlaygroundError::SettingsError)?;
+    let GistWithOwner { owner, gist } = client.get(format!("/gists/{id}"), None::<&()>).await?;
+    if owner.as_ref().map(|owner| owner.login.as_str()) != Some(expected_owner) {
+        return Err(PlaygroundError::NotGistOwner);
+    }
+    Ok(gist.into())
 }
 
 pub async fn save(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,10 @@ pub struct AI {
     pub history_deletion_period_in_sec: u64,
 }
 
+fn default_gist_owner() -> String {
+    "mdn-bot".to_string()
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Playground {
@@ -94,6 +98,8 @@ pub struct Playground {
     #[serde_as(as = "Base64")]
     pub crypt_key: [u8; 32],
     pub flag_repo: String,
+    #[serde(default = "default_gist_owner")]
+    pub github_gist_owner: String,
 }
 
 #[derive(Deserialize)]

--- a/tests/api/play.rs
+++ b/tests/api/play.rs
@@ -67,6 +67,28 @@ async fn test_playground() -> Result<(), Error> {
 
 #[actix_rt::test]
 #[stubr::mock(port = 4321)]
+async fn test_load_gist_wrong_owner() -> Result<(), Error> {
+    let pool = reset()?;
+    let app = test_app_with_login(&pool).await?;
+    let service = test::init_service(app).await;
+    let mut client = TestHttpClient::new(service).await;
+    let gist_id = rumba::api::play::encrypt("8a1f3c5e7b9d2046f1a3")?;
+    let res = client
+        .get(
+            &format!(
+                "/api/v1/play/{}",
+                utf8_percent_encode(&gist_id, NON_ALPHANUMERIC)
+            ),
+            None,
+        )
+        .await;
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    drop_stubr(stubr).await;
+    Ok(())
+}
+
+#[actix_rt::test]
+#[stubr::mock(port = 4321)]
 async fn test_invalid_id() -> Result<(), Error> {
     let pool = reset()?;
     let app = test_app_with_login(&pool).await?;

--- a/tests/stubs/load_gist.json
+++ b/tests/stubs/load_gist.json
@@ -35,6 +35,9 @@
       "description": "An updated gist description.",
       "comments": 0,
       "user": null,
+      "owner": {
+        "login": "mdn-bot"
+      },
       "comments_url": "https://api.github.com/gists/2decf6c462d9b4418f2/comments",
       "forks": [],
       "truncated": false

--- a/tests/stubs/load_gist_wrong_owner.json
+++ b/tests/stubs/load_gist_wrong_owner.json
@@ -1,0 +1,46 @@
+{
+  "uuid": "load_gist_wrong_owner",
+  "request": {
+    "method": "GET",
+    "url": "/gists/8a1f3c5e7b9d2046f1a3"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "url": "https://api.github.com/gists/8a1f3c5e7b9d2046f1a3",
+      "forks_url": "https://api.github.com/gists/8a1f3c5e7b9d2046f1a3/forks",
+      "commits_url": "https://api.github.com/gists/8a1f3c5e7b9d2046f1a3/commits",
+      "id": "8a1f3c5e7b9d2046f1a3",
+      "node_id": "G_kwDOBhHyLdZDliNDQxOGabc",
+      "git_pull_url": "https://gist.github.com/8a1f3c5e7b9d2046f1a3.git",
+      "git_push_url": "https://gist.github.com/8a1f3c5e7b9d2046f1a3.git",
+      "html_url": "https://gist.github.com/8a1f3c5e7b9d2046f1a3",
+      "files": {
+        "playground.json": {
+          "filename": "playground.json",
+          "type": "text/json",
+          "language": "json",
+          "raw_url": "https://gist.githubusercontent.com/octocat/8a1f3c5e7b9d2046f1a3/raw/ac3e6daf176fafe73609fd000cd188e4472010fb/playground.json",
+          "size": 23,
+          "truncated": false,
+          "content": "{\"js\":\"const greeting = 'hello';\",\"css\":\"\",\"html\":\"\"}"
+        }
+      },
+      "public": true,
+      "created_at": "2022-09-20T12:11:58Z",
+      "updated_at": "2022-09-21T10:28:06Z",
+      "description": "A gist owned by another user.",
+      "comments": 0,
+      "user": null,
+      "owner": {
+        "login": "octocat"
+      },
+      "comments_url": "https://api.github.com/gists/8a1f3c5e7b9d2046f1a3/comments",
+      "forks": [],
+      "truncated": false
+    }
+  }
+}


### PR DESCRIPTION
When loading a playground gist, confirm the gist is owned by the configured playground bot account before returning its contents.

Deployed to stage for testing: https://github.com/mdn/rumba/actions/runs/27211577993/job/80341796316