### PR TITLE
chore(deps): bump MSRV from 1.90 to 1.97

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # v1.90
+        uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # v1.97
         with:
           components: rustfmt, clippy
       - name: Cache Cargo registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rumba"
 version = "1.13.7"
 edition = "2021"
-rust-version = "1.90"
+rust-version = "1.97"
 
 [lib]
 path = "src/lib.rs"

--- a/src/ai/explain.rs
+++ b/src/ai/explain.rs
@@ -105,7 +105,7 @@ pub async fn prepare_explain_req(
     let req = CreateChatCompletionRequestArgs::default()
         .model(BASIC_MODEL)
         .messages(vec![system_message, context_message, user_message])
-        .temperature(0.0)
+        .temperature(0.0_f32)
         .build()?;
     Ok(req)
 }

--- a/src/ai/help.rs
+++ b/src/ai/help.rs
@@ -175,7 +175,7 @@ pub async fn prepare_ai_help_req(
     let req = CreateChatCompletionRequestArgs::default()
         .model(config.model)
         .messages(messages)
-        .temperature(0.0)
+        .temperature(0.0_f32)
         .stop(config.stop_phrase.unwrap_or_default())
         .build()?;
     request_meta.model = Some(config.model);
@@ -201,7 +201,7 @@ pub fn prepare_ai_help_summary_req(
     let req = CreateChatCompletionRequestArgs::default()
         .model(BASIC_MODEL)
         .messages(messages)
-        .temperature(0.0)
+        .temperature(0.0_f32)
         .build()?;
 
     Ok(req)

--- a/src/ai/help.rs
+++ b/src/ai/help.rs
@@ -222,8 +222,7 @@ fn qa_check_for_error_trigger(
     {
         if let Some(msg_text) = messages
             .iter()
-            .filter(|m| m.role == Role::User)
-            .next_back()
+            .rfind(|m| m.role == Role::User)
             .and_then(|m| m.content.as_ref())
         {
             if msg_text == magic_words {

--- a/src/api/ai_explain.rs
+++ b/src/api/ai_explain.rs
@@ -77,7 +77,7 @@ pub async fn explain(
                 sse::Data::new_json(GeneratedChunk::from(explanation.as_str()))
                     .map_err(OpenAIError::JSONDeserialize)?,
             ];
-            let stream = futures::stream::iter(parts.into_iter());
+            let stream = futures::stream::iter(parts);
             return Ok(Either::Left(sse::Sse::from_stream(
                 stream.map(|r| Ok::<_, ApiError>(sse::Event::Data(r))),
             )));

--- a/src/api/ai_help.rs
+++ b/src/api/ai_help.rs
@@ -689,8 +689,7 @@ fn qa_check_for_error_trigger(
     {
         if let Some(msg_text) = messages
             .iter()
-            .filter(|m| m.role == Role::User)
-            .next_back()
+            .rfind(|m| m.role == Role::User)
             .and_then(|m| m.content.as_ref())
         {
             if msg_text == magic_words {

--- a/src/api/newsletter.rs
+++ b/src/api/newsletter.rs
@@ -64,7 +64,7 @@ pub async fn subscribe_anonymous_handler(
                 Some(SubscribeOpts {
                     source_url: Some(format!(
                         "{}/en-US/newsletter",
-                        &SETTINGS.application.document_base_url
+                        SETTINGS.application.document_base_url
                     )),
                     ..Default::default()
                 }),
@@ -89,7 +89,7 @@ pub async fn subscribe(
                 optin: Some(YesNo::Y),
                 source_url: Some(format!(
                     "{}/en-US/settings",
-                    &SETTINGS.application.document_base_url
+                    SETTINGS.application.document_base_url
                 )),
                 ..Default::default()
             }),

--- a/src/api/play.rs
+++ b/src/api/play.rs
@@ -161,7 +161,7 @@ pub async fn create_flag_issue(
     if let Some(reason) = reason {
         issue = issue.body(&format!(
             "url: {}/en-US/play?id={}\n{reason}",
-            &SETTINGS.application.document_base_url,
+            SETTINGS.application.document_base_url,
             utf8_percent_encode(&id, NON_ALPHANUMERIC)
         ));
     }

--- a/src/api/v2/multiple_collections.rs
+++ b/src/api/v2/multiple_collections.rs
@@ -294,7 +294,7 @@ pub async fn create_multiple_collection(
     match created {
         Err(db_err) => match db_err {
             DbError::Conflict(_) => Ok(HttpResponse::Conflict().json(ConflictResponse {
-                error: format!("Collection with name '{}' already exists", &req.name),
+                error: format!("Collection with name '{}' already exists", req.name),
             })),
             _ => Err(ApiError::DbError(db_err)),
         },
@@ -325,7 +325,7 @@ pub async fn modify_collection(
     if let Err(db_err) = updated {
         match db_err {
             DbError::Conflict(_) => Ok(HttpResponse::Conflict().json(ConflictResponse {
-                error: format!("Collection with name '{}' already exists", &req.name),
+                error: format!("Collection with name '{}' already exists", req.name),
             })),
             DbError::NotFound(_) => Err(ApiError::CollectionNotFound(c_id.id)),
             _ => Err(ApiError::DbError(db_err)),


### PR DESCRIPTION
### Description

Bumps the Minimal Supported Rust Version (MSRV) from 1.90 to 1.97:

- Updates `rust-version` in `Cargo.toml`
- Updates the `dtolnay/rust-toolchain` pin in `.github/workflows/test.yml`

### Motivation

Consistency across repositories in the MDN organization.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1684.